### PR TITLE
Set NODE_ENV properly for production build

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "main": "dist/aem-vue-editable-components.js",
   "types": "dist/types.d.ts",
   "scripts": {
-    "build:production": "cross-env NODE_ENV=production npm run test:unit && npm run build",
+    "build:production": "cross-env-shell NODE_ENV=production \"npm run test:unit && npm run build\"",
     "build:types": "tsc -p src/tsconfig.types.json",
     "build": "npm run clean && npm run linter && webpack && npm run build:types",
     "clean": "rm -rf dist/",


### PR DESCRIPTION
Currently the `NODE_ENV` variable is only set for the first part of the production build command (`npm run test:unit`) but not the actual build (`npm run build`). This leads to the script file distributed in the package not being minified (and probably other optimizations not being applied as well).