### PR TITLE
Fix empty label of placeholder components not being shown

### DIFF
--- a/src/components/EditableComponent.tsx
+++ b/src/components/EditableComponent.tsx
@@ -98,7 +98,9 @@ export default class EditableComponent extends Mixins(EditableComponentPropertie
 
     return {
       class: Constants._PLACEHOLDER_CLASS_NAMES,
-      'data-emptytext': this.editConfig.emptyLabel
+      attrs: {
+        'data-emptytext': this.editConfig.emptyLabel
+      }
     }
   }
 

--- a/tests/unit/EditableComponent.spec.ts
+++ b/tests/unit/EditableComponent.spec.ts
@@ -98,6 +98,7 @@ describe('EditableComponent ->', () => {
             const vm = mount(withEditable(ChildComponent, EDIT_CONFIG), {
                 attachTo: rootNode,
                 propsData: {
+                    isInEditor: true,
                     ...CQ_PROPS
                 }
             });
@@ -106,7 +107,7 @@ describe('EditableComponent ->', () => {
             const node = vm.find(DATA_PATH_ATTRIBUTE_SELECTOR + ' .' + CHILD_COMPONENT_CLASS_NAME +
                 ' + .' + Constants._PLACEHOLDER_CLASS_NAMES + EMPTY_TEXT_SELECTOR);
 
-            expect(node.exists()).toBe(false);
+            expect(node.exists()).toBe(true);
         });
 
         it('should declare the component to be empty without providing a label', () => {
@@ -133,28 +134,6 @@ describe('EditableComponent ->', () => {
 
             expect(node.exists()).toBe(true);
         });
-
-        it('should declare the component to be empty with a provided label', () => {
-            const EDIT_CONFIG = {
-                isEmpty: function() {
-                    return true;
-                },
-                emptyLabel: EMPTY_LABEL
-            };
-
-            const vm = mount(withEditable(ChildComponent, EDIT_CONFIG), {
-                attachTo: rootNode,
-                propsData: {
-                    isInEditor: true,
-                    ...CQ_PROPS
-                }
-            });
-
-            let node = vm.find(DATA_PATH_ATTRIBUTE_SELECTOR + ' .' + Constants._PLACEHOLDER_CLASS_NAMES + EMPTY_TEXT_SELECTOR);
-
-            expect(node.exists()).toBe(true);
-        });
-
 
         it('should declare the component as not being in the editor', () => {
             const EDIT_CONFIG = {

--- a/tests/unit/EditableComponent.spec.ts
+++ b/tests/unit/EditableComponent.spec.ts
@@ -134,6 +134,28 @@ describe('EditableComponent ->', () => {
             expect(node.exists()).toBe(true);
         });
 
+        it('should declare the component to be empty with a provided label', () => {
+            const EDIT_CONFIG = {
+                isEmpty: function() {
+                    return true;
+                },
+                emptyLabel: EMPTY_LABEL
+            };
+
+            const vm = mount(withEditable(ChildComponent, EDIT_CONFIG), {
+                attachTo: rootNode,
+                propsData: {
+                    isInEditor: true,
+                    ...CQ_PROPS
+                }
+            });
+
+            let node = vm.find(DATA_PATH_ATTRIBUTE_SELECTOR + ' .' + Constants._PLACEHOLDER_CLASS_NAMES + EMPTY_TEXT_SELECTOR);
+
+            expect(node.exists()).toBe(true);
+        });
+
+
         it('should declare the component as not being in the editor', () => {
             const EDIT_CONFIG = {
                 isEmpty: function() {


### PR DESCRIPTION
Currently the `emptyLabel` for the placeholder (i.e. the ` data-emptytext` attribute) from the `editConfig` is not being rendered as it is not passed in the proper property.
This is not caught by the current unit tests as somehow the `isInEditor` flag got lost in translation from the original test case in [aem-react-editable-components](https://github.com/adobe/aem-react-editable-components/blob/1f98fdf2bd63f8523fa2a724fe04e22c0e85a93b/test/EditableComponent.test.tsx#L74) (which actually tests that the label is properly rendered).